### PR TITLE
Revert "Improved Page Load"

### DIFF
--- a/css/globals.css
+++ b/css/globals.css
@@ -6,7 +6,6 @@ body {
 
     margin: 0;
 
-    font-display: optional;
     font-family: 'Poppins', sans-serif;
     line-height: normal;
     color: rgb(245, 245, 245);

--- a/index.html
+++ b/index.html
@@ -11,8 +11,7 @@
 
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link rel="preload" href="https://fonts.googleapis.com/css?family=Poppins:500,700&display=swap" as="font" type="font/woff2" crossorigin>     <!-- ! Select only the weight used -->
-    <!-- ! THIS NOT BEING DEFERRED TAKES 0.2 ON CONTENT DRAW ON PAGE?????????? -->
+    <link href="https://fonts.googleapis.com/css?family=Poppins:500,700&display=swap" rel="stylesheet">     <!-- ! Select only the weight used -->
 
     <link rel="preload" href="./css/globals.css" as="style" onload="this.onload=null; this.rel='stylesheet'">
     <link rel="preload" href="./css/grids.css" as="style" onload="this.onload=null; this.rel='stylesheet'">
@@ -24,7 +23,6 @@
     <noscript><link rel="stylesheet" href="./css/classes.css"></noscript>
     <noscript><link rel="stylesheet" href="./css/animations.css"></noscript>
 
-    <script src="./js/scroll%20resize.js" defer></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/kute.js/2.2.2/kute.min.js" defer></script>
     <script src="./js/blob%20animation.js" defer></script>
 


### PR DESCRIPTION
Reverts ReyasHey/Front-End-Portfolio#5

Even though this improved page load, it also removed the font family if not already installed on the machine that viewed text inside the website.
Reverting this until an efficacious "preload/defer" way of loading the font family is used.